### PR TITLE
Fix to use "CultureInfo.InvariantCulture" for decimal point differences in locales

### DIFF
--- a/Packages/net.yutopp.vjson/Runtime/JsonReader.cs
+++ b/Packages/net.yutopp.vjson/Runtime/JsonReader.cs
@@ -6,6 +6,7 @@
 //
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -340,10 +341,10 @@ namespace VJson
             var span = CommitBuffer();
             if (isFloat)
             {
-                var v = double.Parse(span); // TODO: Fix for large numbers
+                var v = double.Parse(span, CultureInfo.InvariantCulture); // TODO: Fix for large numbers
                 return new FloatNode(v);
             } else {
-                var v = long.Parse(span);   // TODO: Fix for large numbers
+                var v = long.Parse(span, CultureInfo.InvariantCulture);   // TODO: Fix for large numbers
                 return new IntegerNode(v);
             }
         }

--- a/Packages/net.yutopp.vjson/Runtime/Schema/Validator.cs
+++ b/Packages/net.yutopp.vjson/Runtime/Schema/Validator.cs
@@ -189,7 +189,7 @@ namespace VJson.Schema
 
                 case NodeKind.Float:
                 case NodeKind.Integer:
-                    ex = ValidateNumber(Convert.ToDouble(o), state, reg);
+                    ex = ValidateNumber(Convert.ToDouble(o, CultureInfo.InvariantCulture), state, reg);
 
                     if (ex != null)
                     {

--- a/Packages/net.yutopp.vjson/Tests/Runtime/JsonSerializerTest.cs
+++ b/Packages/net.yutopp.vjson/Tests/Runtime/JsonSerializerTest.cs
@@ -9,7 +9,9 @@ using NUnit.Framework;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Threading;
 
 namespace VJson.UnitTests
 {
@@ -1239,6 +1241,163 @@ c
                 new HasNullable {
                     X = 10,
                 },
+            },
+        };
+    }
+
+    class JsonSerializerLocaleTests
+    {
+        CultureInfo _previousCurrentCulture;
+        CultureInfo _previousCurrentUICulture;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            _previousCurrentCulture = Thread.CurrentThread.CurrentCulture;
+            _previousCurrentUICulture = Thread.CurrentThread.CurrentUICulture;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Thread.CurrentThread.CurrentUICulture = _previousCurrentUICulture;
+            Thread.CurrentThread.CurrentCulture = _previousCurrentCulture;
+        }
+
+        [Test]
+        [TestCaseSource(nameof(HasDoubleObjectForLocaleArgs))]
+        [TestCaseSource(nameof(HasLongObjectForLocaleArgs))]
+        public void DeserializationLocaleTest<T>(string o, string localeCode, T expectedObj)
+        {
+            var cultureInfo = new CultureInfo(localeCode);
+            Thread.CurrentThread.CurrentCulture = cultureInfo;
+            Thread.CurrentThread.CurrentUICulture = cultureInfo;
+
+            var obj = new JsonSerializer(typeof(T)).Deserialize(o);
+            Assert.AreEqual(expectedObj, obj);
+        }
+
+        [Json]
+        public class HasDoubleObject : IEquatable<HasDoubleObject>
+        {
+            [JsonField] public double X;
+
+            public bool Equals(HasDoubleObject other)
+            {
+                return X == other.X;
+            }
+        }
+
+        const double DoubleValue = -1.23;
+        const string HasDoubleJson = "{\"X\":-1.23}";
+
+        public static object[] HasDoubleObjectForLocaleArgs = new object[] {
+            new object[] {
+                HasDoubleJson,
+                "en-US",
+                new HasDoubleObject {X = DoubleValue},
+            },
+            new object[] {
+                HasDoubleJson,
+                "es-ES",
+                new HasDoubleObject {X = DoubleValue},
+            },
+            new object[] {
+                HasDoubleJson,
+                "de-DE",
+                new HasDoubleObject {X = DoubleValue},
+            },
+            new object[] {
+                HasDoubleJson,
+                "fr-FR",
+                new HasDoubleObject {X = DoubleValue},
+            },
+            new object[] {
+                HasDoubleJson,
+                "ja-JP",
+                new HasDoubleObject {X = DoubleValue},
+            },
+            new object[] {
+                HasDoubleJson,
+                "zh-TW",
+                new HasDoubleObject {X = DoubleValue},
+            },
+            new object[] {
+                HasDoubleJson,
+                "zh-CN",
+                new HasDoubleObject {X = DoubleValue},
+            },
+            new object[] {
+                HasDoubleJson,
+                "ko-KR",
+                new HasDoubleObject {X = DoubleValue},
+            },
+            new object[] {
+                HasDoubleJson,
+                "th-TH",
+                new HasDoubleObject {X = DoubleValue},
+            },
+        };
+
+        [Json]
+        public class HasLongObject : IEquatable<HasLongObject>
+        {
+            [JsonField] public long X;
+
+            public bool Equals(HasLongObject other)
+            {
+                return X == other.X;
+            }
+        }
+
+        const long LongValue = -23456;
+        const string HasLongJson = "{\"X\":-23456}";
+
+        public static object[] HasLongObjectForLocaleArgs = new object[] {
+            new object[] {
+                HasLongJson,
+                "en-US",
+                new HasLongObject {X = LongValue},
+            },
+            new object[] {
+                HasLongJson,
+                "es-ES",
+                new HasLongObject {X = LongValue},
+            },
+            new object[] {
+                HasLongJson,
+                "de-DE",
+                new HasLongObject {X = LongValue},
+            },
+            new object[] {
+                HasLongJson,
+                "fr-FR",
+                new HasLongObject {X = LongValue},
+            },
+            new object[] {
+                HasLongJson,
+                "ja-JP",
+                new HasLongObject {X = LongValue},
+            },
+            new object[] {
+                HasLongJson,
+                "zh-TW",
+                new HasLongObject {X = LongValue},
+            },
+            new object[] {
+                HasLongJson,
+                "zh-CN",
+                new HasLongObject {X = LongValue},
+            },
+            new object[] {
+                HasLongJson,
+                "ko-KR",
+                new HasLongObject {X = LongValue},
+            },
+            new object[] {
+                HasLongJson,
+                "th-TH",
+                new HasLongObject {X = LongValue},
             },
         };
     }


### PR DESCRIPTION
# Changes
- Fix to use "CultureInfo.InvariantCulture" in `double.Parse` and `Convert.ToDouble`
- Add tests to check results in locales

In JSON, `.` (dot) should be used as a decimal point.

https://datatracker.ietf.org/doc/html/rfc8259#section-6

# Current Behavior
- If **device language setting** is an euro language like French, `JsonSerializer.Deserialize` returns different values from those in English because of the decimal point differences

## i.e. In French
`Convert.ToDouble(v)` without CultureInfo will returns
- `"1,23"` -> `1.23` (as a value in en-US)
- `"1.23"` -> `System.FormatException`

# New Behaviour
- In euro languages, `JsonSerializer.Deserialize` returns same values as those in English